### PR TITLE
Update socialLinks.constants.ts

### DIFF
--- a/src/lib/link/constants/socialLinks.constants.ts
+++ b/src/lib/link/constants/socialLinks.constants.ts
@@ -1,4 +1,4 @@
 export const LINK_SOCIAL_TWITTER = 'https://twitter.com/The_PeopleDAO';
-export const LINK_SOCIAL_DISCORD = 'https://discord.gg/peopledao';
+export const LINK_SOCIAL_DISCORD = 'https://discord.com/invite/9pCtf4xGz2';
 export const LINK_SOCIAL_GITHUB = 'https://github.com/People-DAO';
 export const LINK_SOCIAL_MIRROR = 'https://peopledao.mirror.xyz';


### PR DESCRIPTION
The old discord link for PeopleDAO expires and was taken by the scammer.
We need to update the discord invitation link.